### PR TITLE
fix(app list): make case insensitive

### DIFF
--- a/app/src/main/java/com/kiyui/timur/mvez/SearchActivity.kt
+++ b/app/src/main/java/com/kiyui/timur/mvez/SearchActivity.kt
@@ -189,7 +189,7 @@ class SearchActivity: Activity(), Observer<Action> {
                     val icon = ri.activityInfo.loadIcon(packageManager)
                     AppDetail(label, name, icon) }
                 .filter { app -> app.name != packageName }
-                .sortedWith(compareBy({it.label as String}))
+                .sortedWith(compareBy({ it -> it.label.toString().toUpperCase()}))
     }
 
     /**


### PR DESCRIPTION
Make app list non-case sensitive so `a` and `A` for example are clustered together. Perhaps can make this an option in the future.