### PR TITLE
fix(resume): reload all apps on application resume

### DIFF
--- a/app/src/main/java/com/kiyui/timur/mvez/SearchActivity.kt
+++ b/app/src/main/java/com/kiyui/timur/mvez/SearchActivity.kt
@@ -176,6 +176,15 @@ class SearchActivity: Activity(), Observer<Action> {
     }
 
     /**
+     * Force update apps on resume
+     */
+    /
+    override fun onResume() {
+        super.onResume()
+        setApps(getApps())
+    }
+
+    /**
      * Get applications in alphabetical order
      */
     private fun getApps (): List<AppDetail> {

--- a/app/src/main/java/com/kiyui/timur/mvez/SearchActivity.kt
+++ b/app/src/main/java/com/kiyui/timur/mvez/SearchActivity.kt
@@ -178,7 +178,6 @@ class SearchActivity: Activity(), Observer<Action> {
     /**
      * Force update apps on resume
      */
-    /
     override fun onResume() {
         super.onResume()
         setApps(getApps())


### PR DESCRIPTION
Make application refresh all apps on main activity `onResume`.

This should have been fixed in #6 but seems to still occur. May need to investigate and test if this is too costly an application.